### PR TITLE
3.1.30

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ about:
     It provides abstractions of git objects for easy access of repository data, and additionally allows you to access the git repository more directly using either a pure python implementation, or the faster, but more resource intensive git command implementation.
 
     The object database implementation is optimized for handling large quantities of objects and large datasets, which is achieved by using low-level structures and data streaming.
-  doc_url: http://gitpython.readthedocs.org
+  doc_url: https://gitpython.readthedocs.io
   dev_url: https://github.com/gitpython-developers/GitPython
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.1.18" %}
+{% set version = "3.1.30" %}
 
 package:
   name: gitpython
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/G/GitPython/GitPython-{{ version }}.tar.gz
-  sha256: b838a895977b45ab6f0cc926a9045c8d1c44e2b653c1fcc39fe91f42c6e8f05b
+  sha256: 769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,12 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: Python Git Library
+  description: |
+    GitPython is a python library used to interact with git repositories, high-level like git-porcelain, or low-level like git-plumbing.
+
+    It provides abstractions of git objects for easy access of repository data, and additionally allows you to access the git repository more directly using either a pure python implementation, or the faster, but more resource intensive git command implementation.
+
+    The object database implementation is optimized for handling large quantities of objects and large datasets, which is achieved by using low-level structures and data streaming.
   doc_url: http://gitpython.readthedocs.org
   dev_url: https://github.com/gitpython-developers/GitPython
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: 769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8
 
 build:
-  number: 1
-  noarch: python
+  number: 0
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -21,7 +21,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.5
+    - python
     - gitdb >=4.0.1,<5
     - typing-extensions >=3.7.4.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - gitdb >=4.0.1,<5
-    - typing-extensions >=3.7.4.0  # [py<38]
+    - typing-extensions >=3.7.4.3  # [py<38]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - gitdb >=4.0.1,<5
-    - typing-extensions >=3.7.4.0
+    - typing-extensions >=3.7.4.0  # [py<38]
 
 test:
   requires:


### PR DESCRIPTION
# gitpython 3.1.30

jira: https://anaconda.atlassian.net/browse/PKG-1026
upstream: https://github.com/gitpython-developers/GitPython/tree/3.1.30
`requirements.txt`: https://github.com/gitpython-developers/GitPython/blob/3.1.30/requirements.txt
`setup.py`: https://github.com/gitpython-developers/GitPython/blob/3.1.30/setup.py
license: https://github.com/gitpython-developers/GitPython/blob/3.1.30/LICENSE

## Changes
- Bump version and SHA
- Update about section
- remove noarch
- adjust dependency requirements from upstream

## Notes
- Adds a fix for CVE-2022-24439
