### PR TITLE
[PKG-2825] gitpython 3.1.37

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: gitpython
-  # Versions 3.1.4, 3.1.15, 3.1.16, 3.1.17 have been yanked
+  # Versions 3.1.4, 3.1.15-17, 3.1.19-23 have been yanked
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.1.30" %}
+{% set version = "3.1.37" %}
 
 package:
   name: gitpython
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/G/GitPython/GitPython-{{ version }}.tar.gz
-  sha256: 769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8
+  sha256: f9b9ddc0761c125d5780eab2d64be4873fc6817c2899cbcb34b02344bdc7bc54
 
 build:
   number: 0
   skip: True  # [py<37]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:


### PR DESCRIPTION
**Current package info**


| Channel | Downloads | Version | Platforms | License |
| --- | --- | --- | --- | --- |
| defaults | [![Conda Downloads](https://img.shields.io/conda/dn/anaconda/gitpython.svg)](https://anaconda.org/main/gitpython) | [![Conda Version](https://img.shields.io/conda/vn/main/gitpython.svg)](https://anaconda.org/main/gitpython) | [![Conda Platforms](https://img.shields.io/conda/pn/main/gitpython.svg)](https://anaconda.org/main/gitpython) | ![Conda License](https://img.shields.io/conda/l/main/gitpython) |

Changelog: https://github.com/gitpython-developers/GitPython/releases
License: https://github.com/gitpython-developers/GitPython/blob/3.1.37/LICENSE
Requirements:
- https://github.com/gitpython-developers/GitPython/blob/3.1.37/pyproject.toml
- https://github.com/gitpython-developers/GitPython/blob/3.1.37/setup.py
- https://github.com/gitpython-developers/GitPython/blob/3.1.37/requirements.txt

Actions:
1. Add `--no-build-isolation` to `script`

Notes:
- To address CVEs: CVE-2023-40267, CVE-2023-40590, CVE-2023-41040
