### PR TITLE
gitpython 3.1.43

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,12 @@
-{% set version = "3.1.37" %}
+{% set version = "3.1.43" %}
 
 package:
   name: gitpython
-  # Versions 3.1.4, 3.1.15-17, 3.1.19-23 have been yanked
   version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/G/GitPython/GitPython-{{ version }}.tar.gz
-  sha256: f9b9ddc0761c125d5780eab2d64be4873fc6817c2899cbcb34b02344bdc7bc54
+  sha256: 35f314a9f878467f5453cc1fee295c3e18e52f1b99f10f6cf5b1682e968a9e7c
 
 build:
   number: 0
@@ -44,7 +43,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: Python Git Library
+  summary: GitPython is a python library used to interact with Git repositories.
   description: |
     GitPython is a python library used to interact with git repositories, high-level like git-porcelain, or low-level like git-plumbing.
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-3897](https://anaconda.atlassian.net/browse/PKG-3897)
- release-notes: https://github.com/gitpython-developers/GitPython/releases
- release-diff: https://github.com/gitpython-developers/GitPython/compare/3.1.37...3.1.43
- license: https://github.com/gitpython-developers/GitPython/blob/main/LICENSE
- requirements-tagged:
  - https://github.com/gitpython-developers/GitPython/blob/3.1.43/pyproject.toml
  - https://github.com/gitpython-developers/GitPython/blob/3.1.43/requirements.txt
  - https://github.com/gitpython-developers/GitPython/blob/3.1.43/setup.py


### Explanation of changes:

- Remove an obsolete comment
- Update summary

### Notes:

- v3.1.41 fixes CVE-2024-22190, see https://github.com/gitpython-developers/GitPython/pull/1792

[PKG-3897]: https://anaconda.atlassian.net/browse/PKG-3897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ