### PR TITLE
gitpython 3.1.46 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
   requires:
     - pip
     # Fix "ImportError: Bad git executable." for Windows
-    - git # [win]
+    - git
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,8 @@ test:
     - git.repo
   requires:
     - pip
+    # Fix "ImportError: Bad git executable." for Windows
+    - git # [win]
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "GitPython" %}
-{% set version = "3.1.45" %}
+{% set version = "3.1.46" %}
 
 package:
   name: {{ name|lower }}
@@ -7,8 +7,8 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz
-  sha256: 85b0ee964ceddf211c41b9f27a49086010a190fd8132a24e21f362a4b36a791c
-  
+  sha256: 400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f
+
 build:
   number: 0
   skip: true  # [py<37]


### PR DESCRIPTION
gitpython 3.1.46 

**Destination channel:** Defaults

### Links

- [PKG-11796]
- dev_url:        https://github.com/gitpython-developers/GitPython/tree/3.1.46
- conda_forge:    https://github.com/conda-forge/gitpython-feedstock
- pypi:           https://pypi.org/project/gitpython/3.1.46
- pypi inspector: https://inspector.pypi.io/project/gitpython/3.1.46

### Explanation of changes:

- new version number - 3.1.46
- add py314 build
- add 'git' in test section for ~~Windows~~ all platfroms - missing git binary in CI


[PKG-11796]: https://anaconda.atlassian.net/browse/PKG-11796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ